### PR TITLE
arch: add loongarch support.

### DIFF
--- a/arch/arch-loongarch.h
+++ b/arch/arch-loongarch.h
@@ -10,10 +10,6 @@
 #if __loongarch_xlen == 64
 #define CTZ "ctz.d"
 #define CTO "cto.d"
-#else
-#define CTZ "ctz.w"
-#define CTO "cto.w"
-#endif
 static inline int arch_ffz(unsigned long bitmask)
 {
 	unsigned long count;
@@ -33,5 +29,7 @@ static inline int arch_ffz(unsigned long bitmask)
 }
 
 #define ARCH_HAVE_FFZ
+
+#endif
 
 #endif

--- a/arch/arch-loongarch.h
+++ b/arch/arch-loongarch.h
@@ -7,14 +7,19 @@
 #define write_barrier()		__asm__ __volatile__("dbar 0": : :"memory")
 #define nop			__asm__ __volatile__("nop")
 
-#if __loongarch_xlen == 64
-#define CTZ "ctz.d"
-#define CTO "cto.d"
 static inline int arch_ffz(unsigned long bitmask)
 {
 	unsigned long count;
 	if (~bitmask == 0)	/* ffz() in lib/ffz.h does this. */
+#if __loongarch_xlen == 64
 		return 63;
+#define CTZ "ctz.d"
+#define CTO "cto.d"
+#else
+		return 31;
+#define CTZ "ctz.w"
+#define CTO "cto.w"
+#endif
 
 	__asm__ __volatile__ (CTZ " %0, %1\n\t"
 			      "bnez %0, 0f\n\t"
@@ -29,7 +34,5 @@ static inline int arch_ffz(unsigned long bitmask)
 }
 
 #define ARCH_HAVE_FFZ
-
-#endif
 
 #endif

--- a/arch/arch-loongarch.h
+++ b/arch/arch-loongarch.h
@@ -1,0 +1,37 @@
+#ifndef ARCH_LOONGARCH_H
+#define ARCH_LOONGARCH_H
+
+#define FIO_ARCH	(arch_loongarch)
+
+#define read_barrier()		__asm__ __volatile__("dbar 0": : :"memory")
+#define write_barrier()		__asm__ __volatile__("dbar 0": : :"memory")
+#define nop			__asm__ __volatile__("nop")
+
+#if __loongarch_xlen == 64
+#define CTZ "ctz.d"
+#define CTO "cto.d"
+#else
+#define CTZ "ctz.w"
+#define CTO "cto.w"
+#endif
+static inline int arch_ffz(unsigned long bitmask)
+{
+	unsigned long count;
+	if (~bitmask == 0)	/* ffz() in lib/ffz.h does this. */
+		return 63;
+
+	__asm__ __volatile__ (CTZ " %0, %1\n\t"
+			      "bnez %0, 0f\n\t"
+			      CTO " %0, %1\n\t"
+			      "b 1f\n\t"
+			      "0: move %0, $zero\n\t"
+			      "1:\n\t"
+			      :"=&r"(count)
+			      :"r"(bitmask));
+
+	return count;
+}
+
+#define ARCH_HAVE_FFZ
+
+#endif

--- a/arch/arch.h
+++ b/arch/arch.h
@@ -19,6 +19,7 @@ enum {
 	arch_hppa,
 	arch_mips,
 	arch_aarch64,
+	arch_loongarch,
 
 	arch_generic,
 
@@ -77,6 +78,8 @@ extern unsigned long arch_flags;
 #include "arch-hppa.h"
 #elif defined(__aarch64__)
 #include "arch-aarch64.h"
+#elif defined(__loongarch__)
+#include "arch-loongarch.h"
 #else
 #warning "Unknown architecture, attempting to use generic model."
 #include "arch-generic.h"

--- a/os/os-linux-syscall.h
+++ b/os/os-linux-syscall.h
@@ -263,8 +263,8 @@
 #define __NR_sys_vmsplice	294
 #endif
 
-/* Linux syscalls for aarch64 */
-#elif defined(ARCH_AARCH64_H)
+/* Linux syscalls for aarch64 and loongarch */
+#elif defined(ARCH_AARCH64_H) || defined(ARCH_LOONGARCH_H)
 #ifndef __NR_ioprio_set
 #define __NR_ioprio_set		30
 #define __NR_ioprio_get		31


### PR DESCRIPTION
This patch adds support for loongarch for fio.  This is tested by building
FIO on an loongarch Debian 10 system.

@loongarch64/dev-team 请帮忙review并测试，谢谢。

如果做make fulltest，请打开内核下列选项
CONFIG_BLK_DEV_NULL_BLK=m
CONFIG_BLK_DEV_ZONED=y

**NOTE：**
其中sudo t/zbd/run-tests-against-nullb -s 4时，会出现"null_blk does not support conventional zones"，这个问题看着和本次修改无关。